### PR TITLE
ignore CVE-2020-8561 & CVE-2023-29401

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -4,3 +4,6 @@ sonatype-2022-6522 until=2023-06-01
 # there is no available fix yet
 # Externally Controlled Reference to a Resource in Another Sphere
 CVE-2020-8561
+
+# gRPC HTTP2 header size exceeded error
+CVE-2023-29401

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -2,4 +2,5 @@
 sonatype-2022-6522 until=2023-06-01
 
 # there is no available fix yet
-CVE-2020-8561 until=2023-05-01
+# Externally Controlled Reference to a Resource in Another Sphere
+CVE-2020-8561

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
 
 ### Changed
 
 - Push to Vsphere and Cloud Director app collection. Don't push to Openstack app collection.
+- Re-ignore CVE-2020-8561
+- Add ignore for CVE-2023-29401
 
 ## [0.1.3] - 2023-03-16
 


### PR DESCRIPTION
This PR ignores the following CVEs:

- CVE-2020-8561 - Externally Controlled Reference to a Resource in Another Sphere
  - [we ignore this everywhere already](https://github.com/search?q=org%3Agiantswarm%20CVE-2020-8561&type=code)
- CVE-2023-29401 - gRPC HTTP2 header size exceeded error
  - [we ignore this everywhere already](https://github.com/search?q=org%3Agiantswarm+CVE-2023-32731&type=code)

- ignore CVE-2020-8561 & CVE-2023-29401

## Checklist

- [x] Update changelog in CHANGELOG.md.
