### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.1.4] - 2023-08-24
 
 ### Changed

--- a/helm/deletion-blocker-operator/values.schema.json
+++ b/helm/deletion-blocker-operator/values.schema.json
@@ -156,7 +156,15 @@
                     "type": "boolean"
                 },
                 "capabilities": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 },
                 "seccompProfile": {
                     "type": "object",

--- a/helm/deletion-blocker-operator/values.yaml
+++ b/helm/deletion-blocker-operator/values.yaml
@@ -5,7 +5,7 @@ image:
   name: "giantswarm/deletion-blocker-operator"
   tag: "[[ .Version ]]"
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 logLevel: 0
 


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
