### PR TITLE
Use static `finalizer` instead of creating a dynamic `finalizer` based on the rule contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change container image registry in Makefile to `gsoci.azurecr.io`
+- Use static `finalizer` instead of creating a dynamic `finalizer` based on the rule contents.
 
 ## [0.3.1] - 2024-11-07
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3393

The controller was using a dynamic finalizer based on the contents of the rules. But if the contents of the rules change after the finalizer was added to the reconciled CR, the finalizer will never be removed, because the old finalizer will still be there forever.

## Checklist

- [X] Update changelog in CHANGELOG.md.
