### PR TITLE
Remove finalizer from CAPA CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove finalizer from reconciled CAPA CRs.
+
 ## [0.4.0] - 2025-10-01
 
 ### Changed

--- a/controllers/rule_controller.go
+++ b/controllers/rule_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -54,6 +55,31 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req reconcile.Request) (
 }
 
 func (r *RuleReconciler) reconcileNormal(ctx context.Context, logger logr.Logger, managed *unstructured.Unstructured) (reconcile.Result, error) {
+	// We are removing this controller from CAPA MCs, so we want to remove the finalizer from all reconciled CAPA CRs
+	if managed.GetKind() == "AWSMachineTemplate" {
+		logger.Info("Detected AWSMachineTemplate, removing all finalizers containing the Finalizer constant")
+		finalizersRemoved := false
+		currentFinalizers := managed.GetFinalizers()
+		newFinalizers := []string{}
+
+		for _, finalizer := range currentFinalizers {
+			if strings.Contains(finalizer, Finalizer) {
+				logger.Info("Removing finalizer", "finalizer", finalizer)
+				finalizersRemoved = true
+			} else {
+				newFinalizers = append(newFinalizers, finalizer)
+			}
+		}
+
+		if finalizersRemoved {
+			managed.SetFinalizers(newFinalizers)
+			if err := r.Update(ctx, managed); err != nil {
+				return reconcile.Result{}, microerror.Mask(err)
+			}
+		}
+		return reconcile.Result{}, nil
+	}
+
 	// If the managed resource doesn't have the finalizer, add it.
 	if !controllerutil.ContainsFinalizer(managed, r.legacyFinalizer) && !controllerutil.ContainsFinalizer(managed, Finalizer) {
 		controllerutil.AddFinalizer(managed, Finalizer)


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3393

We are planning on getting rid of this component for CAPA MCs. Before removing it, we want to automatically remove finalizers from CAPA CRs, so we don't have to do the clean up manually.

## Checklist

- [X] Update changelog in CHANGELOG.md.
