### PR TITLE
Remove code that took care of removing finalizer from CAPA CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove code that took care of removing finalizer from CAPA CRs.
+
 ## [0.5.0] - 2025-10-07
 
 ### Changed


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3393

I've deployed the previous version on all MCs. That version removed the finalizers from CAPA CRs. Now we can remove the code, because CAPA CRs no longer have the finalizer. After that, we can finally remove this controller from CAPA MCs.

## Checklist

- [X] Update changelog in CHANGELOG.md.
